### PR TITLE
added spacing consideration to hidden items array margin

### DIFF
--- a/org.kde.plasma.private.systemtray/contents/ui/main.qml
+++ b/org.kde.plasma.private.systemtray/contents/ui/main.qml
@@ -360,8 +360,8 @@ MouseArea {
         id: expander
         anchors {
             fill: parent
-            leftMargin: vertical ? 0 : parent.width - implicitWidth
-            topMargin: vertical ? parent.height - implicitHeight : 0
+            leftMargin: vertical ? 0 : parent.width - implicitWidth - plasmoid.configuration.iconsSpacing
+            topMargin: vertical ? parent.height - implicitHeight - plasmoid.configuration.iconsSpacing : 0
         }
     }
 


### PR DESCRIPTION
When using icons spacing, the hidden icons array is ill positioned (too much on the right). This fix takes into account the icons spacing to position the arrow correctly.