### PR TITLE
Avoid name conflict with Qt

### DIFF
--- a/org.kde.plasma.private.systemtray/contents/ui/ConfigEntries.qml
+++ b/org.kde.plasma.private.systemtray/contents/ui/ConfigEntries.qml
@@ -187,14 +187,14 @@ ColumnLayout {
                             return 0
                         }
 
-                        property var currentValue: model[currentIndex].value
+                        property var myCurrentValue: model[currentIndex].value
 
                         onActivated: {
                             var shownIndex = cfg_shownItems.indexOf(itemId)
                             var hiddenIndex = cfg_hiddenItems.indexOf(itemId)
                             var extraIndex = cfg_extraItems.indexOf(itemId)
 
-                            switch (currentValue) {
+                            switch (myCurrentValue) {
                             case "auto":
                                 if (shownIndex > -1) {
                                     cfg_shownItems.splice(shownIndex, 1)
@@ -295,7 +295,7 @@ ColumnLayout {
                         Component.onCompleted: itemsList.keySequenceColumnWidth = Math.max(implicitWidth, itemsList.keySequenceColumnWidth)
 
                         visible: isPlasmoid
-                        enabled: visibilityComboBox.currentValue !== "disabled"
+                        enabled: visibilityComboBox.myCurrentValue !== "disabled"
                         keySequence: model.applet ? model.applet.globalShortcut : ""
                         onKeySequenceChanged: {
                             if (model.applet && keySequence !== model.applet.globalShortcut) {


### PR DESCRIPTION
https://doc.qt.io/qt-5/qml-qtquick-controls2-combobox.html#currentValue-prop
Use the same `myCurrentValue` name with [Plasma's code](https://github.com/KDE/plasma-workspace/blob/0daf417b18c82d0f62fe4304878d7d52b9efa6c7/applets/systemtray/package/contents/ui/ConfigEntries.qml#L172).

Fix #2 